### PR TITLE
RD-94 Java 8 Map API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
+2019-03-14
+==========
+Pre-Release 2.2.0
+- (TZ for Improbable) Added Java 8 Map API to V13 and V16 (putIfAbsent(), compute(), ...)
+  Only comput() and computeIfPresent() are currently optimized.
+
 2019-02-26
 ==========
-Pre-Release 2.1.0
+Release 2.1.0
 - (TZ for Improbable) Some cleanup and javadoc updates
 - (TZ for Improbable) Improvements for running multiple PH-Trees concurrently:
     - removed AtomicInt entry counter

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,8 @@
 ==========
 Pre-Release 2.2.0
 - (TZ for Improbable) Added Java 8 Map API to V13 and V16 (putIfAbsent(), compute(), ...)
-  Only comput() and computeIfPresent() are currently optimized.
+  Only compute() and computeIfPresent() are currently optimized.
+- (TZ for Improbable) Several minor speed improvements to V13 and V16, including reduced garbage createion.
 
 2019-02-26
 ==========
@@ -10,7 +11,7 @@ Release 2.1.0
 - (TZ for Improbable) Some cleanup and javadoc updates
 - (TZ for Improbable) Improvements for running multiple PH-Trees concurrently:
     - removed AtomicInt entry counter
-    - Changed Object/array pools to be unsynchronized and local (to the tree) instead of global and synchronmized.
+    - Changed Object/array pools to be unsynchronized and local (to the tree) instead of global and synchronized.
 
 
 2018-12-04

--- a/src/main/java/ch/ethz/globis/phtree/PhTree.java
+++ b/src/main/java/ch/ethz/globis/phtree/PhTree.java
@@ -47,7 +47,6 @@ import ch.ethz.globis.phtree.v16hd.PhTree16HD;
  */
 public interface PhTree<T> {
 
-
 	/**
 	 * @return The number of entries in the tree
 	 */
@@ -57,7 +56,6 @@ public interface PhTree<T> {
 	 * @return PH-Tree statistics
 	 */
 	PhTreeStats getStats();
-
 
 	/**
 	 * Insert an entry associated with a k dimensional key.
@@ -208,7 +206,7 @@ public interface PhTree<T> {
 	static <T> PhTree<T> create(int dim) {
 		if (dim > 60) {
 			return new PhTree16HD<>(dim);
-		} else if (dim >= 0) {
+		} else if (dim >= 8) {
 			return new PhTree16<>(dim);
 		}
 		return new PhTree13<>(dim);
@@ -224,7 +222,7 @@ public interface PhTree<T> {
 	static <T> PhTree<T> create(PhTreeConfig cfg) {
 		if (cfg.getDim() > 60) {
 			return new PhTree16HD<>(cfg);
-		} else if (cfg.getDim() >= 0) {
+		} else if (cfg.getDim() >= 8) {
 			return new PhTree16<>(cfg);
 		}
 		return new PhTree13<>(cfg);
@@ -314,35 +312,84 @@ public interface PhTree<T> {
 
 	// Overrides of JDK8 Map extension methods
 
+	/**
+	 * @see java.util.Map#getOrDefault(Object, Object)
+	 * @param key key
+	 * @param defaultValue default value
+	 * @return actual value or default value
+	 */
 	default T getOrDefault(long[] key, T defaultValue) {
 		T t = get(key);
 		return t == null ? defaultValue : t;
 	}
 
+	/**
+	 * @see java.util.Map#putIfAbsent(Object, Object)
+	 * @param key key
+	 * @param value new value
+	 * @return previous value or null
+	 */
 	default T putIfAbsent(long[] key, T value) {
 		throw new UnsupportedOperationException();
 	}
 
+	/**
+	 * @see java.util.Map#remove(Object, Object)
+	 * @param key key
+	 * @param value value
+	 * @return {@code true} if the value was removed
+	 */
 	default boolean remove(long[] key, T value) {
 		throw new UnsupportedOperationException();
 	}
 
+	/**
+	 * @see java.util.Map#replace(Object, Object, Object)
+	 * @param key key
+	 * @param oldValue old value
+	 * @param newValue new value
+	 * @return {@code true} if the value was replaced
+	 */
 	default boolean replace(long[] key, T oldValue, T newValue) {
 		throw new UnsupportedOperationException();
 	}
 
+	/**
+	 * @see java.util.Map#replace(Object, Object)
+	 * @param key key
+	 * @param value new value
+	 * @return previous value or null
+	 */
 	default T replace(long[] key, T value) {
 		throw new UnsupportedOperationException();
 	}
 
+	/**
+	 * @see java.util.Map#computeIfAbsent(Object, Function)
+	 * @param key key
+	 * @param mappingFunction mapping function
+	 * @return new value or null if none is associated
+	 */
 	default T computeIfAbsent(long[] key, Function<long[], ? extends T> mappingFunction) {
 		throw new UnsupportedOperationException();
 	}
 
+	/**
+	 * @see java.util.Map#computeIfPresent(Object, BiFunction)
+	 * @param key key
+	 * @param remappingFunction mapping function
+	 * @return new value or null if none is associated
+	 */
 	default T computeIfPresent(long[] key, BiFunction<long[], ? super T, ? extends T> remappingFunction) {
 		throw new UnsupportedOperationException();
 	}
 
+	/**
+	 * @see java.util.Map#compute(Object, BiFunction)
+	 * @param key key
+	 * @param remappingFunction mapping function
+	 * @return new value or null if none is associated
+	 */
 	default T compute(long[] key, BiFunction<long[], ? super T, ? extends T> remappingFunction) {
 		throw new UnsupportedOperationException();
 	}

--- a/src/main/java/ch/ethz/globis/phtree/PhTree.java
+++ b/src/main/java/ch/ethz/globis/phtree/PhTree.java
@@ -20,6 +20,8 @@
 package ch.ethz.globis.phtree;
 
 import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import ch.ethz.globis.phtree.util.PhIteratorBase;
 import ch.ethz.globis.phtree.util.PhMapper;
@@ -308,5 +310,41 @@ public interface PhTree<T> {
 	 * Clear the tree.
 	 */
 	void clear();
+
+
+	// Overrides of JDK8 Map extension methods
+
+	default T getOrDefault(long[] key, T defaultValue) {
+		T t = get(key);
+		return t == null ? defaultValue : t;
+	}
+
+	default T putIfAbsent(long[] key, T value) {
+		throw new UnsupportedOperationException();
+	}
+
+	default boolean remove(long[] key, T value) {
+		throw new UnsupportedOperationException();
+	}
+
+	default boolean replace(long[] key, T oldValue, T newValue) {
+		throw new UnsupportedOperationException();
+	}
+
+	default T replace(long[] key, T value) {
+		throw new UnsupportedOperationException();
+	}
+
+	default T computeIfAbsent(long[] key, Function<long[], ? extends T> mappingFunction) {
+		throw new UnsupportedOperationException();
+	}
+
+	default T computeIfPresent(long[] key, BiFunction<long[], ? super T, ? extends T> remappingFunction) {
+		throw new UnsupportedOperationException();
+	}
+
+	default T compute(long[] key, BiFunction<long[], ? super T, ? extends T> remappingFunction) {
+		throw new UnsupportedOperationException();
+	}
 }
 

--- a/src/main/java/ch/ethz/globis/phtree/PhTree.java
+++ b/src/main/java/ch/ethz/globis/phtree/PhTree.java
@@ -208,7 +208,7 @@ public interface PhTree<T> {
 	static <T> PhTree<T> create(int dim) {
 		if (dim > 60) {
 			return new PhTree16HD<>(dim);
-		} else if (dim >= 8) {
+		} else if (dim >= 0) {
 			return new PhTree16<>(dim);
 		}
 		return new PhTree13<>(dim);
@@ -224,7 +224,7 @@ public interface PhTree<T> {
 	static <T> PhTree<T> create(PhTreeConfig cfg) {
 		if (cfg.getDim() > 60) {
 			return new PhTree16HD<>(cfg);
-		} else if (cfg.getDim() >= 8) {
+		} else if (cfg.getDim() >= 0) {
 			return new PhTree16<>(cfg);
 		}
 		return new PhTree13<>(cfg);

--- a/src/main/java/ch/ethz/globis/phtree/PhTreeHelper.java
+++ b/src/main/java/ch/ethz/globis/phtree/PhTreeHelper.java
@@ -227,5 +227,16 @@ public abstract class PhTreeHelper {
 		}
     }
 
+
+	public static <T> Object maskNull(T value) {
+		return value == null ? PhTreeHelper.NULL : value;
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T unmaskNull(Object value) {
+		return value == PhTreeHelper.NULL ? null : (T) value;
+	}
+
+
 }
 

--- a/src/main/java/ch/ethz/globis/phtree/PhTreeHelper.java
+++ b/src/main/java/ch/ethz/globis/phtree/PhTreeHelper.java
@@ -88,7 +88,7 @@ public abstract class PhTreeHelper {
 		ARRAY_POOLING = flag;
 	}
 	
-    public static final void debugCheck() {
+    public static void debugCheck() {
     	if (DEBUG) {
     		System.err.println("*************************************");
     		System.err.println("** WARNING ** DEBUG IS ENABLED ******");
@@ -101,7 +101,7 @@ public abstract class PhTreeHelper {
 //    	}
     }
     
-	public static final int align8(int n) {
+	public static int align8(int n) {
     	return (int) (8*Math.ceil(n/8.0));
     }
 
@@ -112,7 +112,7 @@ public abstract class PhTreeHelper {
 	 * @param bitsToCheck number of bits to check (starting with least significant bit)
      * @return Position of the highest conflicting bit (counted from the right) or 0 if none.
 	 */
-    public static final int getMaxConflictingBits(long[] v1, long[] v2, int bitsToCheck) {
+    public static int getMaxConflictingBits(long[] v1, long[] v2, int bitsToCheck) {
     	if (bitsToCheck == 0) {
     		return 0;
     	}
@@ -128,7 +128,7 @@ public abstract class PhTreeHelper {
      * @param mask Mask that indicates which bits to check. Only bits where mask=1 are checked.
      * @return Number of conflicting bits or 0 if none.
      */
-    public static final int getMaxConflictingBitsWithMask(long[] v1, long[] v2, long mask) {
+    public static int getMaxConflictingBitsWithMask(long[] v1, long[] v2, long mask) {
         long x = 0;
         for (int i = 0; i < v1.length; i++) {
         	//write all differences to x, we just check x afterwards
@@ -148,7 +148,7 @@ public abstract class PhTreeHelper {
      * @param postLen the postfix length
      * @return Encoded HC position
      */
-    public static final long posInArray(long[] valSet, int postLen) {
+    public static long posInArray(long[] valSet, int postLen) {
         //n=DIM,  i={0..n-1}
         // i = 0 :  |0|1|0|1|0|1|0|1|
         // i = 1 :  | 0 | 1 | 0 | 1 |
@@ -157,7 +157,7 @@ public abstract class PhTreeHelper {
         //Following formula was for inverse ordering of current ordering...
         //pos = sum (i=1..n, len/2^i) = sum (..., 2^(n-i))
 
-    	long valMask = 1l << postLen;
+    	long valMask = 1L << postLen;
     	
         long pos = 0;
         for (int i = 0; i < valSet.length; i++) {

--- a/src/main/java/ch/ethz/globis/phtree/v13/Node.java
+++ b/src/main/java/ch/ethz/globis/phtree/v13/Node.java
@@ -366,17 +366,18 @@ public class Node {
 		//The parent is then updated with the new sub-node and the current node gets a shorter
 		//infix.
 
-		long[] buffer = new long[newKey.length];
+		long[] buffer = tree.longPool().getArray(newKey.length);
 		int maxConflictingBits = calcConflictingBits(newKey, offs, buffer, mask);
 		if (maxConflictingBits == 0) {
 			if (!(currentValue instanceof Node)) {
 				values[pin] = newValue;
 			}
+			tree.longPool().offer(buffer);
 			return currentValue;
 		}
 
-		Node newNode =
-				createNode(newKey, newValue, buffer, currentValue, maxConflictingBits, tree);
+		Node newNode = createNode(newKey, newValue, buffer, currentValue, maxConflictingBits, tree);
+		tree.longPool().offer(buffer);
 
 		replaceEntryWithSub(pin, hcPos, newKey, newNode, tree);
 		tree.increaseNrEntries();
@@ -387,9 +388,10 @@ public class Node {
 	private <T> Object insertSplitCompute(long[] newKey, Object currentValue, boolean doIfAbsent, Node parent,
 										  int pin, long hcPos, PhTree13<?> tree, int offs, long mask,
 										  BiFunction<long[], ? super T, ? extends T> remappingFunction) {
-		long[] buffer = new long[newKey.length];
+		long[] buffer = tree.longPool().getArray(newKey.length);
 		int maxConflictingBits = calcConflictingBits(newKey, offs, buffer, mask);
 		if (maxConflictingBits == 0) {
+			tree.longPool().offer(buffer);
 			if (currentValue instanceof Node) {
 				//This is a node;
 				return currentValue;
@@ -406,16 +408,19 @@ public class Node {
 
 		//No exact match
 		if (!doIfAbsent) {
+			tree.longPool().offer(buffer);
 			return null;
 		}
 
 		T newValue = remappingFunction.apply(newKey, null);
 		if (newValue != null) {
+			tree.longPool().offer(buffer);
 			values[pin] = newValue;
 			return newValue;
 		}
 
 		Node newNode = createNode(newKey, newValue, buffer, currentValue, maxConflictingBits, tree);
+		tree.longPool().offer(buffer);
 		replaceEntryWithSub(pin, hcPos, newKey, newNode, tree);
 		tree.increaseNrEntries();
 		//entry did not exist

--- a/src/main/java/ch/ethz/globis/phtree/v13/Node.java
+++ b/src/main/java/ch/ethz/globis/phtree/v13/Node.java
@@ -23,6 +23,8 @@ import static ch.ethz.globis.phtree.PhTreeHelper.posInArray;
 
 import ch.ethz.globis.phtree.PhTreeHelper;
 
+import java.util.function.BiFunction;
+
 
 /**
  * Node of the PH-tree.
@@ -212,10 +214,10 @@ public class Node {
 	 * @return The sub node or null.
 	 */
 	Object doIfMatching(long[] keyToMatch, boolean getOnly, Node parent,
-			long[] newKey, int[] insertRequired, PhTree13<?> tree) {
-		
+						long[] newKey, int[] insertRequired, PhTree13<?> tree) {
+
 		long hcPos = posInArray(keyToMatch, getPostLen());
-		
+
 		int pin;
 		Object v;
 		int offs;
@@ -254,12 +256,64 @@ public class Node {
 			if (getOnly) {
 				return v;
 			} else {
-				return deleteAndMergeIntoParent(pin, hcPos, keyToMatch, 
-							parent, newKey, insertRequired, v, tree);
-			}			
+				return deleteAndMergeIntoParent(pin, hcPos, keyToMatch,
+						parent, newKey, insertRequired, v, tree);
+			}
 		}
 	}
-	
+
+	<T> Object doCompute(long[] keyToMatch, boolean doIfAbsent, Node parent, PhTree13<?> tree,
+					 BiFunction<long[], ? super T, ? extends T> remappingFunction) {
+		long hcPos = posInArray(keyToMatch, getPostLen());
+		int pin = getPosition(hcPos, keyToMatch.length);
+		//check whether hcPos is valid
+		if (pin < 0) {
+			if (doIfAbsent) {
+				T newValue = remappingFunction.apply(keyToMatch, null);
+				if (newValue != null) {
+					tree.increaseNrEntries();
+					addPostPIN(hcPos, pin, keyToMatch, newValue, tree);
+				}
+				return newValue;
+			}
+			return null;
+		}
+
+		Object v;
+		int offs;
+		int dims = keyToMatch.length;
+		if (isAHC()) {
+			v = values[(int) hcPos];
+			offs = posToOffsBitsDataAHC(hcPos, getBitPosIndex(), dims);
+		} else {
+			v = values[pin];
+			offs = pinToOffsBitsDataLHC(pin, getBitPosIndex(), dims);
+		}
+		if (v instanceof Node) {
+			Node sub = (Node) v;
+			if (hasSubInfix(offs, dims)) {
+				long mask = calcInfixMask(sub.getPostLen());
+				return insertSplitCompute(keyToMatch, v, doIfAbsent, parent, pin, hcPos, tree, offs, mask,
+						remappingFunction);
+			}
+			return v;
+		} else {
+			if (getPostLen() > 0) {
+				long mask = calcPostfixMask();
+				return insertSplitCompute(keyToMatch, v, doIfAbsent, parent, pin, hcPos, tree, offs, mask,
+						remappingFunction);
+			}
+			//perfect match
+			T newValue = remappingFunction.apply(keyToMatch, PhTreeHelper.unmaskNull(v));
+			if (newValue == null) {
+				deleteAndMergeIntoParent(pin, hcPos, keyToMatch, parent, null, null, v, tree);
+			} else {
+				values[pin] = newValue;
+			}
+			return newValue;
+		}
+	}
+
 	private boolean readAndCheckKdKey(int offs, long[] keyToMatch, long mask) {
 		for (int i = 0; i < keyToMatch.length; i++) {
 			long k = Bits.readArray(ba, offs, postLenStored());
@@ -296,21 +350,21 @@ public class Node {
 	 */
 	private Object insertSplit(long[] newKey, Object newValue, Object currentValue,
 							   int pin, long hcPos, PhTree13<?> tree, int offs, long mask) {
-        //do the splitting
+		//do the splitting
 
-        //What does 'splitting' mean (we assume there is currently a sub-node, in case of a postfix
-        // work similar):
-        //The current sub-node has an infix that is not (or only partially) compatible with 
-        //the new key.
-        //We create a new intermediary sub-node between the parent node and the current sub-node.
-        //The new key/value (which we want to add) should end up as post-fix for the new-sub node. 
-        //All other current post-fixes and sub-nodes stay in the current sub-node. 
+		//What does 'splitting' mean (we assume there is currently a sub-node, in case of a postfix
+		// work similar):
+		//The current sub-node has an infix that is not (or only partially) compatible with
+		//the new key.
+		//We create a new intermediary sub-node between the parent node and the current sub-node.
+		//The new key/value (which we want to add) should end up as post-fix for the new-sub node.
+		//All other current post-fixes and sub-nodes stay in the current sub-node.
 
-        //How splitting works:
-        //We insert a new node between the current and the parent node:
-        //  parent -> newNode -> node
-        //The parent is then updated with the new sub-node and the current node gets a shorter
-        //infix.
+		//How splitting works:
+		//We insert a new node between the current and the parent node:
+		//  parent -> newNode -> node
+		//The parent is then updated with the new sub-node and the current node gets a shorter
+		//infix.
 
 		long[] buffer = new long[newKey.length];
 		int maxConflictingBits = calcConflictingBits(newKey, offs, buffer, mask);
@@ -320,17 +374,55 @@ public class Node {
 			}
 			return currentValue;
 		}
-		
+
 		Node newNode =
-                createNode(newKey, newValue, buffer, currentValue, maxConflictingBits, tree);
+				createNode(newKey, newValue, buffer, currentValue, maxConflictingBits, tree);
 
-        replaceEntryWithSub(pin, hcPos, newKey, newNode, tree);
-        tree.increaseNrEntries();
+		replaceEntryWithSub(pin, hcPos, newKey, newNode, tree);
+		tree.increaseNrEntries();
 		//entry did not exist
-        return null;
-    }
+		return null;
+	}
 
-    /**
+	private <T> Object insertSplitCompute(long[] newKey, Object currentValue, boolean doIfAbsent, Node parent,
+										  int pin, long hcPos, PhTree13<?> tree, int offs, long mask,
+										  BiFunction<long[], ? super T, ? extends T> remappingFunction) {
+		long[] buffer = new long[newKey.length];
+		int maxConflictingBits = calcConflictingBits(newKey, offs, buffer, mask);
+		if (maxConflictingBits == 0) {
+			if (currentValue instanceof Node) {
+				//This is a node;
+				return currentValue;
+			}
+			//exact match
+			T newValue = remappingFunction.apply(newKey, PhTreeHelper.unmaskNull(currentValue));
+			if (newValue != null) {
+				values[pin] = newValue;
+				return newValue;
+			}
+			deleteAndMergeIntoParent(pin, hcPos, newKey, parent, null, null, null, tree);
+			return null;
+		}
+
+		//No exact match
+		if (!doIfAbsent) {
+			return null;
+		}
+
+		T newValue = remappingFunction.apply(newKey, null);
+		if (newValue != null) {
+			values[pin] = newValue;
+			return newValue;
+		}
+
+		Node newNode = createNode(newKey, newValue, buffer, currentValue, maxConflictingBits, tree);
+		replaceEntryWithSub(pin, hcPos, newKey, newNode, tree);
+		tree.increaseNrEntries();
+		//entry did not exist
+		return newValue;
+	}
+
+	/**
      * 
      * @param key1 key 1
      * @param val1 value 1

--- a/src/main/java/ch/ethz/globis/phtree/v13/PhTree13.java
+++ b/src/main/java/ch/ethz/globis/phtree/v13/PhTree13.java
@@ -94,10 +94,10 @@ import ch.ethz.globis.phtree.util.unsynced.ObjectPool;
 public class PhTree13<T> implements PhTree<T> {
 
 	//Enable HC incrementer / iteration
-	public static final boolean HCI_ENABLED = true; 
+	public static final boolean HCI_ENABLED = true;
 	//Enable AHC mode in nodes
-	static final boolean AHC_ENABLED = true; 
-	
+	static final boolean AHC_ENABLED = true;
+
 	//This threshold is used to decide during query iteration whether the first value
 	//should be found by binary search or by full scan.
 	public static final int LHC_BINARY_SEARCH_THRESHOLD = 50;

--- a/src/main/java/ch/ethz/globis/phtree/v13/PhTree13.java
+++ b/src/main/java/ch/ethz/globis/phtree/v13/PhTree13.java
@@ -19,12 +19,11 @@
  */
 package ch.ethz.globis.phtree.v13;
 
-import static ch.ethz.globis.phtree.PhTreeHelper.align8;
-import static ch.ethz.globis.phtree.PhTreeHelper.debugCheck;
-import static ch.ethz.globis.phtree.PhTreeHelper.posInArray;
-
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import ch.ethz.globis.phtree.PhDistance;
 import ch.ethz.globis.phtree.PhDistanceL;
@@ -39,6 +38,9 @@ import ch.ethz.globis.phtree.util.*;
 import ch.ethz.globis.phtree.util.unsynced.LongArrayPool;
 import ch.ethz.globis.phtree.util.unsynced.ObjectArrayPool;
 import ch.ethz.globis.phtree.util.unsynced.ObjectPool;
+
+import static ch.ethz.globis.phtree.PhTreeHelper.*;
+import static ch.ethz.globis.phtree.PhTreeHelper.maskNull;
 
 /**
  * n-dimensional index (quad-/oct-/n-tree).
@@ -312,6 +314,135 @@ public class PhTree13<T> implements PhTree<T> {
 		}		
 		
 		return (T) value;
+	}
+
+
+
+	// Overrides of new  Java 8 methods
+
+	@Override
+	public T getOrDefault(long[] key, T defaultValue) {
+		T e = get(key);
+		return e == null ? defaultValue : e;
+	}
+
+	@Override
+	public T putIfAbsent(long[] key, T value) {
+		if (getRoot() == null) {
+			insertRoot(key, maskNull(value));
+			return null;
+		}
+
+		T o = get(key);
+		if (o == null) {
+			put(key, value);
+		}
+		return o;
+	}
+
+	@Override
+	public boolean remove(long[] key, T value) {
+		boolean[] o = new boolean[1];
+		computeIfPresent(key, (longs, t) -> (o[0] = Objects.equals(t, value)) ? null : t);
+		return o[0];
+	}
+
+	@Override
+	public boolean replace(long[] key, T oldValue, T newValue) {
+		if (getRoot() == null) {
+			return false;
+		}
+
+		Object o = getRoot();
+		while (o instanceof Node) {
+			Node currentNode = (Node) o;
+			o = currentNode.doIfMatching(key, true, null, null, null, this);
+		}
+
+		if (o != null && Objects.equals(o, oldValue)) {
+			put(key, newValue);
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public T replace(long[] key, T value) {
+		if (getRoot() == null) {
+			return null;
+		}
+
+		Object o = getRoot();
+		while (o instanceof Node) {
+			Node currentNode = (Node) o;
+			o = currentNode.doIfMatching(key, true, null, null, null, this);
+		}
+
+		if (o != null) {
+			put(key, value);
+			return PhTreeHelper.unmaskNull(o);
+		}
+		return null;
+	}
+
+	@Override
+	public T computeIfAbsent(long[] key, Function<long[], ? extends T> mappingFunction) {
+		if (getRoot() == null) {
+			T newValue = mappingFunction.apply(key);
+			if (newValue != null) {
+				insertRoot(key, maskNull(newValue));
+			}
+			return newValue;
+		}
+
+		T currentValue = get(key);
+		if (currentValue == null) {
+			T newValue = mappingFunction.apply(key);
+			if (newValue != null) {
+				put(key, newValue);
+			}
+			return newValue;
+		}
+		return currentValue;
+	}
+
+	@Override
+	public T computeIfPresent(long[] key, BiFunction<long[], ? super T, ? extends T> remappingFunction) {
+		if (getRoot() == null) {
+			return null;
+		}
+
+		T currentValue = get(key);
+		if (currentValue != null) {
+			T newValue = remappingFunction.apply(key, currentValue);
+			if (newValue == null) {
+				remove(key);
+			} else {
+				put(key, newValue);
+			}
+			return newValue;
+		}
+		return null;
+	}
+
+	@Override
+	public T compute(long[] key, BiFunction<long[], ? super T, ? extends T> remappingFunction) {
+		if (getRoot() == null) {
+			T newValue = remappingFunction.apply(key, null);
+			if (newValue != null) {
+				insertRoot(key, maskNull(newValue));
+			}
+			return newValue;
+		}
+
+		T currentValue = get(key);
+		T newValue = remappingFunction.apply(key, currentValue);
+		if (newValue == null) {
+			remove(key);
+		} else {
+			put(key, newValue);
+		}
+		return newValue;
 	}
 
 	@Override

--- a/src/main/java/ch/ethz/globis/phtree/v13/PhTree13.java
+++ b/src/main/java/ch/ethz/globis/phtree/v13/PhTree13.java
@@ -406,25 +406,24 @@ public class PhTree13<T> implements PhTree<T> {
 		return currentValue;
 	}
 
+    @SuppressWarnings("unchecked")
 	@Override
 	public T computeIfPresent(long[] key, BiFunction<long[], ? super T, ? extends T> remappingFunction) {
 		if (getRoot() == null) {
 			return null;
 		}
 
-		T currentValue = get(key);
-		if (currentValue != null) {
-			T newValue = remappingFunction.apply(key, currentValue);
-			if (newValue == null) {
-				remove(key);
-			} else {
-				put(key, newValue);
-			}
-			return newValue;
-		}
-		return null;
+        Object o = getRoot();
+        Node parentNode = null;
+        while (o instanceof Node) {
+            Node currentNode = (Node) o;
+            o = currentNode.doCompute(key, false, parentNode, this, remappingFunction);
+            parentNode = currentNode;
+        }
+        return (T) o;
 	}
 
+    @SuppressWarnings("unchecked")
 	@Override
 	public T compute(long[] key, BiFunction<long[], ? super T, ? extends T> remappingFunction) {
 		if (getRoot() == null) {
@@ -435,15 +434,15 @@ public class PhTree13<T> implements PhTree<T> {
 			return newValue;
 		}
 
-		T currentValue = get(key);
-		T newValue = remappingFunction.apply(key, currentValue);
-		if (newValue == null) {
-			remove(key);
-		} else {
-			put(key, newValue);
-		}
-		return newValue;
-	}
+        Object o = getRoot();
+        Node parentNode = null;
+        while (o instanceof Node) {
+            Node currentNode = (Node) o;
+            o = currentNode.doCompute(key, true, parentNode, this, remappingFunction);
+            parentNode = currentNode;
+        }
+        return (T) o;
+    }
 
 	@Override
 	public String toString() {

--- a/src/main/java/ch/ethz/globis/phtree/v16/Node.java
+++ b/src/main/java/ch/ethz/globis/phtree/v16/Node.java
@@ -595,6 +595,18 @@ public class Node {
 		be.set(hcPos, kdKey, value);
 	}
 
+	Object removeEntry(long hcPos, long[] keyToMatch, Node parent, PhTree16<?> tree) {
+		Object v = removeEntry(hcPos, keyToMatch, (UpdateInfo)null, tree);
+		if (v != null && !(v instanceof Node)) {
+			//Found and removed entry.
+			tree.decreaseNrEntries();
+			if (getEntryCount() == 1) {
+				mergeIntoParentNt(keyToMatch, parent, tree);
+			}
+		}
+		return v;
+	}
+
 	/**
 	 * General contract:
 	 * Returning a value or NULL means: Value was removed, please update global entry counter
@@ -650,7 +662,7 @@ public class Node {
 	}
 	
 	
-	private BSTEntry getEntry(long hcPos, long[] keyToMatch) {
+	BSTEntry getEntry(long hcPos, long[] keyToMatch) {
 		BSTEntry be = bstGet(hcPos);
 		if (be == null) {
 			return null;

--- a/src/main/java/ch/ethz/globis/phtree/v16/Node.java
+++ b/src/main/java/ch/ethz/globis/phtree/v16/Node.java
@@ -22,6 +22,7 @@ import static ch.ethz.globis.phtree.PhTreeHelper.posInArray;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiFunction;
 
 import ch.ethz.globis.phtree.PhEntry;
 import ch.ethz.globis.phtree.PhTreeHelper;
@@ -130,13 +131,13 @@ public class Node {
 	 * @return The sub node or null.
 	 */
 	Object doIfMatching(long[] keyToMatch, boolean getOnly, Node parent, UpdateInfo insertRequired, PhTree16<?> tree) {
-		
+
 		long hcPos = posInArray(keyToMatch, getPostLen());
-		
+
 		if (getOnly) {
 			BSTEntry e = getEntry(hcPos, keyToMatch);
 			return e != null ? e.getValue() : null;
-		}			
+		}
 		Object v = removeEntry(hcPos, keyToMatch, insertRequired, tree);
 		if (v != null && !(v instanceof Node)) {
 			//Found and removed entry.
@@ -147,7 +148,7 @@ public class Node {
 		}
 		return v;
 	}
-	
+
 	private long calcInfixMask(int subPostLen) {
 		//We use a simplified mask, because the prefix is always present
 		//long mask = ~((-1L)<<(getPostLen()-subPostLen-1));
@@ -156,19 +157,18 @@ public class Node {
 	
 
     /**
-     * 
      * @param key1 key 1
      * @param val1 value 1
      * @param key2 key 2
      * @param val2 value 2
-     * @param mcb most conflicting bit
+     * @param mcb  most conflicting bit
 	 * @param tree tree
      * @return A new node or 'null' if there are no conflicting bits
      */
     public Node createNode(long[] key1, Object val1, long[] key2, Object val2, int mcb, PhTree16<?> tree) {
         //determine length of infix
         int newLocalInfLen = getPostLen() - mcb;
-        int newPostLen = mcb-1;
+        int newPostLen = mcb - 1;
         Node newNode = createNode(key1.length, newLocalInfLen, newPostLen, tree);
 
         long posSub1 = posInArray(key1, newPostLen);
@@ -354,18 +354,18 @@ public class Node {
 	int getInfixLen() {
 		return infixLenStored() - 1;
 	}
-	
+
 	private int infixLenStored() {
 		return infixLenStored;
 	}
 
-	void setInfixLen(int newInfLen) {
-		infixLenStored = (byte) (newInfLen + 1);
-	}
+    void setInfixLen(int newInfLen) {
+        infixLenStored = (byte) (newInfLen + 1);
+    }
 
-	public int getPostLen() {
-		return postLenStored - 1;
-	}
+    public int getPostLen() {
+        return postLenStored - 1;
+    }
 
 	int postLenStored() {
 		return postLenStored;
@@ -398,8 +398,8 @@ public class Node {
 				e.setValue(null);
 			}
 			return e;
-		} 
-		
+		}
+
 		Object o = page;
 		while (o instanceof BSTreePage && !((BSTreePage)o).isLeaf()) {
 			o = ((BSTreePage)o).getOrCreate(key, this);
@@ -412,10 +412,10 @@ public class Node {
 		final BSTreePage rootPage = getRoot();
 		if (rootPage.isLeaf()) {
 			return rootPage.remove(key, kdKey, this, ui);
-		} 
-		
+		}
+
 		BSTEntry result = rootPage.findAndRemove(key, kdKey, this, ui);
-		if (rootPage.getNKeys() == 0) { 
+		if (rootPage.getNKeys() == 0) {
 			root = rootPage.getFirstSubPage();
 			tree.bstPool().reportFreeNode(rootPage);
 		}
@@ -423,41 +423,57 @@ public class Node {
 	}
 
 
-	public BSTEntry bstGet(long key) {
-		BSTreePage page = getRoot();
-		while (page != null && !page.isLeaf()) {
-			page = page.findSubPage(key);
-		}
-		if (page == null) {
-			return null;
-		}
-		return page.getValueFromLeaf(key);
-	}
+    public <T> BSTEntry bstCompute(long key, long[] kdKey, boolean doIfAbsent, boolean doIfPresent,
+                                   BiFunction<long[], ? super T, ? extends T> mappingFunction) {
+        final BSTreePage rootPage = getRoot();
+        if (rootPage.isLeaf()) {
+            return rootPage.computeLeaf(key, kdKey, this, doIfAbsent, doIfPresent, mappingFunction);
+        }
+
+        BSTEntry result = rootPage.findAndCompute(key, kdKey, this, doIfAbsent, doIfPresent, mappingFunction);
+        if (rootPage.getNKeys() == 0) {
+            root = rootPage.getFirstSubPage();
+            BSTPool.reportFreeNode(rootPage);
+        }
+        return result;
+    }
+
+
+    public BSTEntry bstGet(long key) {
+        BSTreePage page = getRoot();
+        while (page != null && !page.isLeaf()) {
+            page = page.findSubPage(key);
+        }
+        if (page == null) {
+            return null;
+        }
+        return page.getValueFromLeaf(key);
+    }
 
 	public BSTreePage bstCreatePage(BSTreePage parent, boolean isLeaf, BSTreePage leftPredecessor, PhTree16<?> tree) {
 		return BSTreePage.create(this, parent, isLeaf, leftPredecessor, tree);
 	}
 
-	public BSTreePage getRoot() {
-		return root;
-	}
+    public BSTreePage getRoot() {
+        return root;
+    }
 
-	public void bstUpdateRoot(BSTreePage newRoot) {
-		root = newRoot;
-	}
+    public void bstUpdateRoot(BSTreePage newRoot) {
+        root = newRoot;
+    }
 
-	public String toStringTree() {
-		StringBuilderLn sb = new StringBuilderLn();
-		if (root != null) {
-			root.toStringTree(sb, "");
-		}
-		return sb.toString();
-	}
+    public String toStringTree() {
+        StringBuilderLn sb = new StringBuilderLn();
+        if (root != null) {
+            root.toStringTree(sb, "");
+        }
+        return sb.toString();
+    }
 
-	
-	public BSTIteratorAll iterator() {
-		return new BSTIteratorAll().reset(getRoot());
-	}
+
+    public BSTIteratorAll iterator() {
+        return new BSTIteratorAll().reset(getRoot());
+    }
 
 	
 	public static class BSTStats {
@@ -581,7 +597,7 @@ public class Node {
 			//return previous value
 			return currentValue;
 		}
-		
+
 		Node newNode = createNode(newKey, newValue, localKdKey, currentValue, maxConflictingBits, tree);
 
 		//replace value
@@ -607,104 +623,160 @@ public class Node {
 		return v;
 	}
 
-	/**
-	 * General contract:
-	 * Returning a value or NULL means: Value was removed, please update global entry counter
-	 * Returning a Node means: Traversal not finished, no change in counters
-	 * Returning null means: Entry not found, no change in counters
-	 * 
-	 * Node entry counters are updated internally by the operation
-	 * Node-counting is done by the NodePool.
-	 * 
-	 * @param hcPos hc pos
-	 * @param key key
-	 * @param ui UpdateInfo
-	 * @return See contract.
-	 */
-	private Object removeEntry(long hcPos, long[] key, UpdateInfo ui, PhTree16<?> tree) {
-		//Only remove value-entries, node-entries are simply returned without removing them
-		BSTEntry prev = bstRemove(hcPos, key, ui, tree);
-		//return values: 
-		// - null -> not found / remove failed
-		// - Node -> recurse node
-		// - T -> remove success
-		//Node: removing a node is never necessary: When values are removed from the PH-Tree, nodes are replaced
-		// with vales from sub-nodes, but they are never simply removed.
-		//-> The BST.remove() needs to do:
-		//  - Key not found: no delete, return null
-		//  - No match: no delete, return null
-		//  - Match Node: no delete, return Node
-		//  - Match Value: delete, return value
-		return prev == null ? null : prev.getValue();
-	}
+    <T> Object computeEntry(long hcPos, long[] keyToMatch, Node parent, PhTree16<?> tree,
+                            BiFunction<long[], ? super T, ? extends T> mappingFunction) {
+        Object v = computeEntry(hcPos, keyToMatch, mappingFunction);
+        if (v != null && !(v instanceof Node)) {
+            //Found and removed entry.
+            tree.decreaseNrEntries();
+            if (getEntryCount() == 1) {
+                mergeIntoParentNt(keyToMatch, parent, tree);
+            }
+        }
+        return v;
+    }
 
-	public REMOVE_OP bstInternalRemoveCallback(BSTEntry currentEntry, long[] key, UpdateInfo ui) {
-		if (matches(currentEntry, key)) {
-			if (currentEntry.getValue() instanceof Node) {
-				return REMOVE_OP.KEEP_RETURN;
-			}
-			if (ui != null) {
-				//replace
-				int bitPosOfDiff = Node.calcConflictingBits(key, ui.newKey, -1L);
-				if (bitPosOfDiff <= getPostLen()) {
-					//replace
-					//simply replace kdKey!!
-					//Replacing the long[] should be correct (and fastest, and avoiding GC)
-					currentEntry.set(currentEntry.getKey(), ui.newKey, currentEntry.getValue());
-					return REMOVE_OP.KEEP_RETURN;
-				} else {
-					ui.insertRequired = bitPosOfDiff;
-				}
-			}
-			return REMOVE_OP.REMOVE_RETURN;
-		}
-		return REMOVE_OP.KEEP_RETURN_NULL;
-	}
-	
-	
-	BSTEntry getEntry(long hcPos, long[] keyToMatch) {
-		BSTEntry be = bstGet(hcPos);
-		if (be == null) {
-			return null;
-		}
-		if (keyToMatch != null && !matches(be, keyToMatch)) {
-			return null;
-		}
-		return be; 
-	}
+    /**
+     * General contract:
+     * Returning a value or NULL means: Value was removed, please update global entry counter
+     * Returning a Node means: Traversal not finished, no change in counters
+     * Returning null means: Entry not found, no change in counters
+     * <p>
+     * Node entry counters are updated internally by the operation
+     * Node-counting is done by the NodePool.
+     *
+     * @param hcPos hc pos
+     * @param key   key
+     * @param ui    UpdateInfo
+     * @return See contract.
+     */
+    private Object removeEntry(long hcPos, long[] key, UpdateInfo ui, PhTree16<?> tree) {
+        //Only remove value-entries, node-entries are simply returned without removing them
+        BSTEntry prev = bstRemove(hcPos, key, ui, tree);
+        //return values:
+        // - null -> not found / remove failed
+        // - Node -> recurse node
+        // - T -> remove success
+        //Node: removing a node is never necessary: When values are removed from the PH-Tree, nodes are replaced
+        // with vales from sub-nodes, but they are never simply removed.
+        //-> The BST.remove() needs to do:
+        //  - Key not found: no delete, return null
+        //  - No match: no delete, return null
+        //  - Match Node: no delete, return Node
+        //  - Match Value: delete, return value
+        return prev == null ? null : prev.getValue();
+    }
 
-	
-	private boolean matches(BSTEntry be, long[] keyToMatch) {
-		//This is always 0, unless we decide to put several keys into a single array
-		if (be.getValue() instanceof Node) {
-			Node sub = (Node) be.getValue();
-			if (sub.getInfixLen() > 0) {
-				final long mask = calcInfixMask(sub.getPostLen());
-				return checkKdKey(be.getKdKey(), keyToMatch, mask);
-			}
-			return true;
-		} 
-		
-		return checkKdKey(be.getKdKey(), keyToMatch);
-	}
-	
-	private static boolean checkKdKey(long[] allKeys, long[] keyToMatch, long mask) {
-		for (int i = 0; i < keyToMatch.length; i++) {
-			if (((allKeys[i] ^ keyToMatch[i]) & mask) != 0) {
-				return false;
-			}
-		}
-		return true;
-	}
+    private <T> Object computeEntry(long hcPos, long[] key,
+                                    BiFunction<long[], ? super T, ? extends T> mappingFunction) {
+        //Only remove value-entries, node-entries are simply returned without removing them
+        BSTEntry prev = bstCompute(hcPos, key, mappingFunction);
+        //return values:
+        // - null -> not found / remove failed
+        // - Node -> recurse node
+        // - T -> remove success
+        //Node: removing a node is never necessary: When values are removed from the PH-Tree, nodes are replaced
+        // with vales from sub-nodes, but they are never simply removed.
+        //-> The BST.remove() needs to do:
+        //  - Key not found: no delete, return null
+        //  - No match: no delete, return null
+        //  - Match Node: no delete, return Node
+        //  - Match Value: delete, return value
+        return prev == null ? null : prev.getValue();
+    }
 
-	private static boolean checkKdKey(long[] allKeys, long[] keyToMatch) {
-		for (int i = 0; i < keyToMatch.length; i++) {
-			if ((allKeys[i] ^ keyToMatch[i]) != 0) {
-				return false;
-			}
-		}
-		return true;
-	}
+    public REMOVE_OP bstInternalRemoveCallback(BSTEntry currentEntry, long[] key, UpdateInfo ui) {
+        if (matches(currentEntry, key)) {
+            if (currentEntry.getValue() instanceof Node) {
+                return REMOVE_OP.KEEP_RETURN;
+            }
+            if (ui != null) {
+                //replace
+                int bitPosOfDiff = Node.calcConflictingBits(key, ui.newKey, -1L);
+                if (bitPosOfDiff <= getPostLen()) {
+                    //replace
+                    //simply replace kdKey!!
+                    //Replacing the long[] should be correct (and fastest, and avoiding GC)
+                    currentEntry.set(currentEntry.getKey(), ui.newKey, currentEntry.getValue());
+                    return REMOVE_OP.KEEP_RETURN;
+                } else {
+                    ui.insertRequired = bitPosOfDiff;
+                }
+            }
+            return REMOVE_OP.REMOVE_RETURN;
+        }
+        return REMOVE_OP.KEEP_RETURN_NULL;
+    }
+
+
+    public static <T> REMOVE_OP bstInternalRemoveCallback(BSTEntry currentEntry, long[] key,
+                                                          BiFunction<long[], ? super T, ? extends T> mappingFunction) {
+        if (matches(currentEntry, key)) {
+            if (currentEntry.getValue() instanceof Node) {
+                return REMOVE_OP.KEEP_RETURN;
+            }
+            if (ui != null) {
+                //replace
+                int bitPosOfDiff = Node.calcConflictingBits(key, ui.newKey, -1L);
+                if (bitPosOfDiff <= getPostLen()) {
+                    //replace
+                    //simply replace kdKey!!
+                    //Replacing the long[] should be correct (and fastest, and avoiding GC)
+                    currentEntry.set(currentEntry.getKey(), ui.newKey, currentEntry.getValue());
+                    return REMOVE_OP.KEEP_RETURN;
+                } else {
+                    ui.insertRequired = bitPosOfDiff;
+                }
+            }
+            return REMOVE_OP.REMOVE_RETURN;
+        }
+        return REMOVE_OP.KEEP_RETURN_NULL;
+    }
+
+
+    BSTEntry getEntry(long hcPos, long[] keyToMatch) {
+        BSTEntry be = bstGet(hcPos);
+        if (be == null) {
+            return null;
+        }
+        if (keyToMatch != null && !matches(be, keyToMatch)) {
+            return null;
+        }
+        return be;
+    }
+
+
+    private boolean matches(BSTEntry be, long[] keyToMatch) {
+        //This is always 0, unless we decide to put several keys into a single array
+        if (be.getValue() instanceof Node) {
+            Node sub = (Node) be.getValue();
+            if (sub.getInfixLen() > 0) {
+                final long mask = calcInfixMask(sub.getPostLen());
+                return checkKdKey(be.getKdKey(), keyToMatch, mask);
+            }
+            return true;
+        }
+
+        return checkKdKey(be.getKdKey(), keyToMatch);
+    }
+
+    private static boolean checkKdKey(long[] allKeys, long[] keyToMatch, long mask) {
+        for (int i = 0; i < keyToMatch.length; i++) {
+            if (((allKeys[i] ^ keyToMatch[i]) & mask) != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean checkKdKey(long[] allKeys, long[] keyToMatch) {
+        for (int i = 0; i < keyToMatch.length; i++) {
+            if ((allKeys[i] ^ keyToMatch[i]) != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
 
 
 	void getStats(PhTreeStats stats, List<BSTEntry> entries) {
@@ -729,36 +801,43 @@ public class Node {
 		KEEP_RETURN_NULL
 	}
 
-	public static class BSTEntry {
-		private long key;
-		private long[] kdKey;
-		private Object value;
-		public BSTEntry(long key, long[] k, Object v) {
-			this.key = key;
-			kdKey = k;
-			value = v;
-		}
-		public long getKey() {
-			return key;
-		}
-		public long[] getKdKey() {
-			return kdKey;
-		}
-		public Object getValue() {
-			return value;
-		}
-		public void set(long key, long[] kdKey, Object value) {
-			this.key = key;
-			this.kdKey = kdKey;
-			this.value = value;
-		}
-		@Override
-		public String toString() {
-			return (kdKey == null ? null : Arrays.toString(kdKey)) + "->" + value;
-		}
-		public void setValue(Object value) {
-			this.value = value;
-		}
-	}
+    public static class BSTEntry {
+        private long key;
+        private long[] kdKey;
+        private Object value;
+
+        public BSTEntry(long key, long[] k, Object v) {
+            this.key = key;
+            kdKey = k;
+            value = v;
+        }
+
+        public long getKey() {
+            return key;
+        }
+
+        public long[] getKdKey() {
+            return kdKey;
+        }
+
+        public Object getValue() {
+            return value;
+        }
+
+        public void set(long key, long[] kdKey, Object value) {
+            this.key = key;
+            this.kdKey = kdKey;
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return (kdKey == null ? null : Arrays.toString(kdKey)) + "->" + value;
+        }
+
+        public void setValue(Object value) {
+            this.value = value;
+        }
+    }
 
 }

--- a/src/main/java/ch/ethz/globis/phtree/v16/Node.java
+++ b/src/main/java/ch/ethz/globis/phtree/v16/Node.java
@@ -449,13 +449,14 @@ public class Node {
 		BSTEntry result = rootPage.findAndRemove(key, kdKey, this, ui);
 		if (rootPage.getNKeys() == 0) {
 			root = rootPage.getFirstSubPage();
+			root.setParent(null);
 			tree.bstPool().reportFreeNode(rootPage);
 		}
 		return result;
 	}
 
 
-    public <T> Object bstCompute(long key, long[] kdKey, PhTree16<?> tree, boolean doIfAbsent, boolean doIfPresent,
+    public <T> Object bstCompute(long key, long[] kdKey, PhTree16<?> tree, boolean doIfAbsent,
                                    BiFunction<long[], ? super T, ? extends T> mappingFunction) {
         BSTreePage page = getRoot();
         int pos = -1;
@@ -463,7 +464,7 @@ public class Node {
             pos = page.binarySearchInnerNode(key);
             page = page.getSubPages()[pos];
         }
-        Object result = page.computeLeaf(key, kdKey, pos, this, doIfAbsent, doIfPresent, mappingFunction);
+        Object result = page.computeLeaf(key, kdKey, pos, this, doIfAbsent, mappingFunction);
 
         BSTreePage rootPage = getRoot();
         if (!rootPage.isLeaf() && rootPage.getNKeys() == 0) {
@@ -660,9 +661,8 @@ public class Node {
 	}
 
     <T> Object computeEntry(long hcPos, long[] keyToMatch, Node parent, PhTree16<?> tree,
-                            boolean doIfAbsent, boolean doIfPresent,
-                            BiFunction<long[], ? super T, ? extends T> mappingFunction) {
-        Object v = bstCompute(hcPos, keyToMatch, tree,  doIfAbsent, doIfPresent, mappingFunction);
+                            boolean doIfAbsent, BiFunction<long[], ? super T, ? extends T> mappingFunction) {
+        Object v = bstCompute(hcPos, keyToMatch, tree,  doIfAbsent, mappingFunction);
         //Check for removed elements
         if (getEntryCount() == 1) {
             mergeIntoParentNt(keyToMatch, parent, tree);

--- a/src/main/java/ch/ethz/globis/phtree/v16/PhTree16.java
+++ b/src/main/java/ch/ethz/globis/phtree/v16/PhTree16.java
@@ -469,7 +469,7 @@ public class PhTree16<T> implements PhTree<T> {
 		while (o instanceof Node) {
 			Node currentNode = (Node) o;
 			long hcPos = posInArray(key, currentNode.getPostLen());
-			o = currentNode.computeEntry(hcPos, key, parentNode, this, false, true, remappingFunction);
+			o = currentNode.computeEntry(hcPos, key, parentNode, this, false, remappingFunction);
 			parentNode = currentNode;
 			// Node: recurse
 			// Otherwise: return value
@@ -493,7 +493,7 @@ public class PhTree16<T> implements PhTree<T> {
 		while (o instanceof Node) {
 			Node currentNode = (Node) o;
 			long hcPos = posInArray(key, currentNode.getPostLen());
-			o = currentNode.computeEntry(hcPos, key, parentNode, this, true, true, remappingFunction);
+			o = currentNode.computeEntry(hcPos, key, parentNode, this, true, remappingFunction);
 			parentNode = currentNode;
             // Node: recurse
             // Otherwise: return value

--- a/src/main/java/ch/ethz/globis/phtree/v16/bst/BSTPool.java
+++ b/src/main/java/ch/ethz/globis/phtree/v16/bst/BSTPool.java
@@ -30,7 +30,8 @@ public class BSTPool {
     private final ObjectArrayPool<BSTEntry> entryArrayPool = ObjectArrayPool.create(n -> new BSTEntry[n]);
     private final LongArrayPool longArrayPool = LongArrayPool.create();
 	private final ObjectArrayPool<BSTreePage> pageArrayPool = ObjectArrayPool.create(n -> new BSTreePage[n]);
-    private final ObjectPool<BSTreePage> pagePool = ObjectPool.create(null);
+	private final ObjectPool<BSTreePage> pagePool = ObjectPool.create(null);
+	private final ObjectPool<BSTEntry> poolEntries = ObjectPool.create(BSTEntry::new);
 
     public static BSTPool create(){
     	return new BSTPool();
@@ -132,4 +133,12 @@ public class BSTPool {
 		return new BSTreePage(ind, parent, isLeaf, leftPredecessor, tree);
 	}
 
+	public BSTEntry getEntry() {
+    	return poolEntries.get();
+	}
+
+	public void offerEntry(BSTEntry entry) {
+    	entry.set(0, null, null);
+    	poolEntries.offer(entry);
+	}
 }

--- a/src/main/java/ch/ethz/globis/phtree/v16/bst/BSTPool.java
+++ b/src/main/java/ch/ethz/globis/phtree/v16/bst/BSTPool.java
@@ -28,10 +28,10 @@ import ch.ethz.globis.phtree.v16.PhTree16;
 public class BSTPool {
 
     private final ObjectArrayPool<BSTEntry> entryArrayPool = ObjectArrayPool.create(n -> new BSTEntry[n]);
-    private final LongArrayPool longArrayPool = LongArrayPool.create();
+    private final LongArrayPool keyPool = LongArrayPool.create();
 	private final ObjectArrayPool<BSTreePage> pageArrayPool = ObjectArrayPool.create(n -> new BSTreePage[n]);
 	private final ObjectPool<BSTreePage> pagePool = ObjectPool.create(null);
-	private final ObjectPool<BSTEntry> poolEntries = ObjectPool.create(BSTEntry::new);
+	private final ObjectPool<BSTEntry> entryPool = ObjectPool.create(BSTEntry::new);
 
     public static BSTPool create(){
     	return new BSTPool();
@@ -70,7 +70,7 @@ public class BSTPool {
      * @return New array.
      */
     public long[] arrayCreateLong(int newSize) {
-    	return longArrayPool.getArray(newSize);
+    	return keyPool.getArray(newSize);
 	}
 
 	
@@ -81,9 +81,9 @@ public class BSTPool {
      * @return New array larger array.
      */
     public long[] arrayExpand(long[] oldA, int newSize) {
-    	long[] newA = longArrayPool.getArray(newSize);
+    	long[] newA = keyPool.getArray(newSize);
     	System.arraycopy(oldA, 0, newA, 0, oldA.length);
-    	longArrayPool.offer(oldA);
+    	keyPool.offer(oldA);
     	return newA;
 	}
 
@@ -112,7 +112,7 @@ public class BSTPool {
 
 	
 	public void reportFreeNode(BSTreePage p) {
-		longArrayPool.offer(p.getKeys());
+		keyPool.offer(p.getKeys());
 		if (p.isLeaf()) {
 			p.updateNeighborsRemove();
 			entryArrayPool.offer(p.getValues());
@@ -134,11 +134,11 @@ public class BSTPool {
 	}
 
 	public BSTEntry getEntry() {
-    	return poolEntries.get();
+    	return entryPool.get();
 	}
 
-	public void offerEntry(BSTEntry entry) {
+	void offerEntry(BSTEntry entry) {
     	entry.set(0, null, null);
-    	poolEntries.offer(entry);
+    	entryPool.offer(entry);
 	}
 }

--- a/src/main/java/ch/ethz/globis/phtree/v16/bst/BSTreePage.java
+++ b/src/main/java/ch/ethz/globis/phtree/v16/bst/BSTreePage.java
@@ -185,17 +185,32 @@ public class BSTreePage {
 
 
 	public int binarySearchInnerNode(long key) {
-		//The stored value[i] is the min-values of the according page[i+1}
-		//read page before that value
-		//TODO simplify
-		int pos = binarySearch(key);
-		if (pos >= 0) {
-			//pos of matching key
-			pos++;
-		} else {
-			pos = -(pos+1);
+		if (nEntries <=8) {
+			long[] keys = this.keys;
+			for (int i = 0; i < nEntries; i++) {
+				if (key <= keys[i]) {
+					return key == keys[i] ? i+1 : i;
+				}
+			}
+			return nEntries;  // key not found.
 		}
-		return pos;
+		long[] keys = this.keys;
+		int low = 0;
+		int high = nEntries - 1;
+
+		while (low <= high) {
+			int mid = (low + high) >>> 1;
+			long midVal = keys[mid];
+
+			if (midVal < key)
+				low = mid + 1;
+			else if (midVal > key)
+				high = mid - 1;
+			else {
+				return mid+1; // key found
+			}
+		}
+		return low;  // key not found.
 	}
 
 	/**
@@ -204,7 +219,7 @@ public class BSTreePage {
 	 * @param key search key
 	 */
 	int binarySearch(long key) {
-		if (nEntries <=6) {
+		if (nEntries <=8) {
 			return linearSearch(key);
 		}
 		long[] keys = this.keys;
@@ -419,12 +434,10 @@ public class BSTreePage {
 			//add page here
 			
 			if (keyPos == NO_POS) {
-			
 				//For now, we assume a unique index.
-				int i = binarySearch(minKey);
+				keyPos = binarySearchInnerNode(minKey);
 				//If the key has a perfect match then something went wrong. This should
 				//never happen so we don't need to check whether (i < 0).
-				keyPos = -(i+1);
 			}
 			
 			if (keyPos > 0) {

--- a/src/test/java/ch/ethz/globis/phtree/bst/TestBST16compute.java
+++ b/src/test/java/ch/ethz/globis/phtree/bst/TestBST16compute.java
@@ -83,7 +83,7 @@ public class TestBST16compute {
 			//if (i%1000 == 0) 
 			//System.out.println("ins=" + i);
 			//ht.bstPut((Integer)i.getValue(), i);
-			ht.bstCompute((int)i.getValue(), i.getKdKey(), tree, true, true, (longs, o) -> {
+			ht.bstCompute((int)i.getValue(), i.getKdKey(), tree, true, (longs, o) -> {
 				assertSame(i.getKdKey(), longs);
 				assertNull(o);
 				//TODO clone 'i'?
@@ -136,7 +136,7 @@ public class TestBST16compute {
 		long l31 = System.currentTimeMillis();
 		for (BSTEntry i : list) {
 			//ht.bstPut((Integer)i.getValue(), new BSTEntry(i.getKdKey(), -(Integer)i.getValue()));
-			ht.bstCompute((Integer)i.getValue(), i.getKdKey(), tree, true, true,
+			ht.bstCompute((Integer)i.getValue(), i.getKdKey(), tree, true,
 					(longs, o) -> -(Integer)i.getValue() );
 		}
 		long l32 = System.currentTimeMillis();
@@ -147,7 +147,7 @@ public class TestBST16compute {
 		boolean[] found = new boolean[1];
 		for (BSTEntry i : list) {
 			found[0] = false;
-			ht.bstCompute((Integer)i.getValue(), i.getKdKey(), tree, true, true,
+			ht.bstCompute((Integer)i.getValue(), i.getKdKey(), tree, true,
 					(longs, o) -> {
 						found[0] = true;
 						return null;

--- a/src/test/java/ch/ethz/globis/phtree/bst/TestBST16compute.java
+++ b/src/test/java/ch/ethz/globis/phtree/bst/TestBST16compute.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2016-2018 Tilmann Zäschke. All Rights Reserved.
+ *
+ * This software is the proprietary information of Tilmann Zäschke.
+ * Use is subject to license terms.
+ */
+package ch.ethz.globis.phtree.bst;
+
+import ch.ethz.globis.phtree.v16.Node;
+import ch.ethz.globis.phtree.v16.Node.BSTEntry;
+import ch.ethz.globis.phtree.v16.PhTree16;
+import ch.ethz.globis.phtree.v16.bst.BSTIteratorAll;
+import ch.ethz.globis.phtree.v16.bst.BSTIteratorMask;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.*;
+
+public class TestBST16compute {
+
+	private static final int N1 = 100_000;
+	private static final int N2 = 10*N1;
+	
+	private static final int DIM = 10;
+	private static final PhTree16<Object> tree = new PhTree16<>(DIM);
+	
+	private Node create() {
+		return Node.createNode(DIM, 0, 63, tree);
+	}
+	
+	@Test
+	public void testBSTree() {
+		runTest(createData(N1), "");
+		System.gc();
+		runTest(createData(N2), "");
+		System.gc();
+		runTest(createData(N2), "");
+	}
+	
+	
+	@Test
+	public void testBSTreeRND() {
+//		for (int i = 0; i < 1000; i++) {
+//			System.out.println("seed=" + i);
+//			runTest(createDataRND(i, 44), "R-");
+//		}
+//		runTest(createDataRND(834, 44), "R-");
+		runTest(createDataRND(0, N1), "R-");
+		System.gc();
+		runTest(createDataRND(0, N2), "R-");
+		System.gc();
+		runTest(createDataRND(0, N2), "R-");
+	}
+	
+	private static BSTEntry createEntry(int i) {
+		BSTEntry e = new BSTEntry(i, new long[DIM], i);
+		e.getKdKey()[0] = i;
+		return e;
+	}
+	
+	private List<BSTEntry> createData(int n) {
+		return IntStream.range(0, n).boxed().map(TestBST16compute::createEntry).collect(Collectors.toList());
+	}
+	
+	private List<BSTEntry> createDataRND(int seed, int n) {
+		List<BSTEntry> list = createData(n);
+		Collections.shuffle(list, new Random(seed));
+		return list;
+	}
+	
+	private void runTest(List<BSTEntry> list, String prefix) {
+		Node ht = create();
+	
+		
+		//populate
+		long l11 = System.currentTimeMillis();
+		for (BSTEntry i : list) {
+			//if (i%1000 == 0) 
+			//System.out.println("ins=" + i);
+			//ht.bstPut((Integer)i.getValue(), i);
+			ht.bstCompute((int)i.getValue(), i.getKdKey(), tree, true, true, (longs, o) -> {
+				assertSame(i.getKdKey(), longs);
+				assertNull(o);
+				//TODO clone 'i'?
+				return i.getValue();
+			});
+
+			//Check
+			BSTEntry be = ht.bstGet((Integer)i.getValue());
+			assertEquals((int)i.getValue(), (int)be.getValue());
+		}
+		long l12 = System.currentTimeMillis();
+		assertEquals(list.size(), ht.getEntryCount());
+		
+		println(ht.getStats().toString());
+		
+		//lookup
+		long l21 = System.currentTimeMillis();
+		for (BSTEntry i : list) {
+			BSTEntry e = ht.bstGet((Integer)i.getValue());
+			//assertNotNull("i=" + i, e);
+			int x = (int) e.getValue();
+			assertEquals(i.getValue(), x);
+		}
+		long l22 = System.currentTimeMillis();
+		
+		//iterate
+		long l51 = System.currentTimeMillis();
+		BSTIteratorAll iter = ht.iterator();
+		long prev = -1;
+		while (iter.hasNextEntry()) {
+			long current = iter.nextEntry().getKey();
+			assertEquals(prev + 1, current);
+			prev = current;
+		}
+		assertEquals(prev, list.size() - 1);
+		long l52 = System.currentTimeMillis();
+
+		long l61 = System.currentTimeMillis();
+		BSTIteratorMask iterMask = new BSTIteratorMask().reset(ht.getRoot(), 0, 0xFFFFFFFFFFFEL, ht.getEntryCount());
+		prev = -2;
+		while (iterMask.hasNextEntry()) {
+			long current = iterMask.nextEntry().getKey();
+			assertEquals(prev + 2, current);
+			prev = current;
+		}
+		assertEquals(prev, ((list.size()-1) & 0xFFFFFFFE));
+		long l62 = System.currentTimeMillis();
+		
+		//replace some
+		long l31 = System.currentTimeMillis();
+		for (BSTEntry i : list) {
+			//ht.bstPut((Integer)i.getValue(), new BSTEntry(i.getKdKey(), -(Integer)i.getValue()));
+			ht.bstCompute((Integer)i.getValue(), i.getKdKey(), tree, true, true,
+					(longs, o) -> -(Integer)i.getValue() );
+		}
+		long l32 = System.currentTimeMillis();
+		assertEquals(list.size(), ht.getEntryCount());
+		
+		//remove some
+		long l41 = System.currentTimeMillis();
+		boolean[] found = new boolean[1];
+		for (BSTEntry i : list) {
+			found[0] = false;
+			ht.bstCompute((Integer)i.getValue(), i.getKdKey(), tree, true, true,
+					(longs, o) -> {
+						found[0] = true;
+						return null;
+					});
+			assertTrue(found[0]);
+		}
+		long l42 = System.currentTimeMillis();
+		assertEquals(0, ht.getEntryCount());
+		
+		println(prefix + "Load: " + (l12-l11));
+		println(prefix + "Get:  " + (l22-l21));
+		println(prefix + "Iter: " + (l52-l51));
+		println(prefix + "IterM:" + (l62-l61));
+		println(prefix + "Load: " + (l32-l31));
+		println(prefix + "Rem : " + (l42-l41));
+		println();
+	}
+	
+	
+	private static void println() {
+		println("");
+	}
+
+	private static void println(String str) {
+		System.out.println(str);
+	}
+	
+	
+	@Test
+	public void testEmpty() {
+		Node ht = create();
+		checkEmpty(ht);
+	}
+	
+	@Test
+	public void testEmptyAfterLoad() {
+		Node ht = create();
+		
+		for (int r = 0; r < 10; r++) {
+		
+			for (int i = 0; i < 100000; i++) {
+				BSTEntry e = ht.bstGetOrCreate(i, tree);
+				e.set(i, new long[] {i}, i);
+			}
+			
+			for (int i = 0; i < 100000; i++) {
+				BSTEntry e = ht.bstRemove(i, new long[] {i}, null, tree);
+				assertEquals(i, (int)e.getValue());
+			}
+		
+			checkEmpty(ht);
+		}
+	}
+	
+	private void checkEmpty(Node ht) {
+		assertEquals(0, ht.getEntryCount());
+		
+		BSTEntry e = ht.bstGet(12345);
+		assertNull(e);
+		
+		//iterate
+		BSTIteratorAll iter = ht.iterator();
+		assertFalse(iter.hasNextEntry());
+
+		BSTIteratorMask iterMask = new BSTIteratorMask().reset(ht.getRoot(), 0, 0xFFFFFFFFFFFEL, ht.getEntryCount());
+		assertFalse(iterMask.hasNextEntry());
+				
+		BSTEntry e2 = ht.bstRemove(12345, null, null, tree);
+		assertNull(e2);
+	}
+
+}

--- a/src/test/java/ch/ethz/globis/phtree/test/BenchmarkJava8MapAPI.java
+++ b/src/test/java/ch/ethz/globis/phtree/test/BenchmarkJava8MapAPI.java
@@ -13,6 +13,8 @@ import ch.ethz.globis.phtree.v16.PhTree16;
 
 import java.util.Arrays;
 import java.util.Random;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 
 public class BenchmarkJava8MapAPI extends TestSuper {
@@ -21,26 +23,55 @@ public class BenchmarkJava8MapAPI extends TestSuper {
 	private static final int DIMS = 3;
 	private static final int LIMIT_MS = 1000;
 
+	private static class Scenario {
+		String name;
+		Supplier<PhTree<int[]>> constructor;
+		BiConsumer<PhTree<int[]>, long[]> action;
+		Scenario(String name, Supplier<PhTree<int[]>> constructor,
+				 BiConsumer<PhTree<int[]>, long[]> action) {
+			this.name = name;
+			this.constructor = constructor;
+			this.action = action;
+		}
+	}
+
+
 	public static void main(String[] args) {
 		long[][] data = generate();
-		testGetPut13(data);
-		testGetPut13(data);
-		testGetPut13(data);
-		testGetPut16(data);
-		testGetPut16(data);
-		testGetPut16(data);
-		testCompute16(data);
-		testCompute16(data);
-		testCompute16(data);
-		testGetPut13(data);
-		testGetPut13(data);
-		testGetPut13(data);
-		testGetPut16(data);
-		testGetPut16(data);
-		testGetPut16(data);
-		testCompute16(data);
-		testCompute16(data);
-		testCompute16(data);
+
+		Scenario s13getPut =
+				new Scenario("PHTree13-GP: ", () -> new PhTree13<>(DIMS), BenchmarkJava8MapAPI::actionGetPut);
+		Scenario s16getPut =
+				new Scenario("PHTree16-GP: ", () -> new PhTree16<>(DIMS), BenchmarkJava8MapAPI::actionGetPut);
+		Scenario s16comp =
+				new Scenario("PHTree16-CO: ", () -> new PhTree16<>(DIMS), BenchmarkJava8MapAPI::actionCompute);
+
+		test3(data, s13getPut);
+		test3(data, s16getPut);
+		test3(data, s16comp);
+		test3(data, s13getPut);
+		test3(data, s16getPut);
+		test3(data, s16comp);
+	}
+
+	private static void actionGetPut(PhTree<int[]> tree, long[] key) {
+		int[] x = tree.get(key);
+		if (x == null) {
+			x = new int[]{0};
+			tree.put(key, x);
+		} else {
+			x[0]++;
+		}
+	}
+
+	private static void actionCompute(PhTree<int[]> tree, long[] key) {
+		tree.compute(key, (longs, ints) -> {
+			if (ints == null) {
+				return new int[]{0};
+			}
+			ints[0]++;
+			return ints;
+		});
 	}
 
 	private static long[][] generate() {
@@ -52,58 +83,38 @@ public class BenchmarkJava8MapAPI extends TestSuper {
 		return data;
 	}
 
-	private static void testGetPut13(long[][] data) {
-		PhTree13<int[]> tree = new PhTree13<>(DIMS);
+	private static void test3(long[][] data, Scenario scenario) {
+		for (int i =- 0; i < 3; i++) {
+			test(data, scenario.name, scenario.constructor, scenario.action);
+		}
+	}
+
+	private static void test(long[][] data, String name, Supplier<PhTree<int[]>> constructor,
+							 BiConsumer<PhTree<int[]>, long[]> action) {
+		rest();
+		PhTree<int[]> tree = constructor.get();
 		long t0 = System.currentTimeMillis();
 		int n = 0;
-		while (n % 100 != 0 || System.currentTimeMillis()-t0 < LIMIT_MS) {
-			long[] key = data[n++ % N_POINTS];
-			int[] x = tree.get(key);
-			if (x == null) {
-				x = new int[]{0};
-				tree.put(key, x);
-			} else {
-				x[0]++;
+		while (System.currentTimeMillis()-t0 < LIMIT_MS) {
+			for (int i = 0; i < 100; i++) {
+				long[] key = data[n++ % N_POINTS];
+				action.accept(tree, key);
 			}
 		}
 		long t1 = System.currentTimeMillis();
-		System.out.println("PHTree13-GP: " + (t1-t0)/(double)n*1_000_000 + " ops/s");
+		System.out.println(name + n/(double)(t1-t0)*1_000 + " ops/s");
 	}
 
-	private static void testGetPut16(long[][] data) {
-		PhTree16<int[]> tree = new PhTree16<>(DIMS);
-		long t0 = System.currentTimeMillis();
-		int n = 0;
-		while (n % 100 != 0 || System.currentTimeMillis()-t0 < LIMIT_MS) {
-			long[] key = data[n++ % N_POINTS];
-			int[] x = tree.get(key);
-			if (x == null) {
-				x = new int[]{0};
-				tree.put(key, x);
-			} else {
-				x[0]++;
-			}
+	private static void rest() {
+		try {
+			System.gc();
+			Thread.sleep(100);
+			System.gc();
+			Thread.sleep(100);
+			System.gc();
+			Thread.sleep(100);
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
 		}
-		long t1 = System.currentTimeMillis();
-		System.out.println("PHTree16-GP: " + (t1-t0)/(double)n*1_000_000 + " ops/s");
 	}
-
-	private static void testCompute16(long[][] data) {
-		PhTree16<int[]> tree = new PhTree16<>(DIMS);
-		long t0 = System.currentTimeMillis();
-		int n = 0;
-		while (n % 100 != 0 || System.currentTimeMillis()-t0 < LIMIT_MS) {
-			long[] key = data[n++ % N_POINTS];
-			tree.compute(key, (longs, ints) -> {
-				if (ints == null) {
-					return new int[]{0};
-				}
-				ints[0]++;
-				return ints;
-			});
-		}
-		long t1 = System.currentTimeMillis();
-		System.out.println("PHTree16-CO: " + (t1-t0)/(double)n*1_000_000 + " ops/s");
-	}
-
 }

--- a/src/test/java/ch/ethz/globis/phtree/test/BenchmarkJava8MapAPI.java
+++ b/src/test/java/ch/ethz/globis/phtree/test/BenchmarkJava8MapAPI.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2011-2016 ETH Zurich. All Rights Reserved.
+ *
+ * This software is the proprietary information of ETH Zurich.
+ * Use is subject to license terms.
+ */
+package ch.ethz.globis.phtree.test;
+
+import ch.ethz.globis.phtree.PhTree;
+import ch.ethz.globis.phtree.test.util.TestSuper;
+import ch.ethz.globis.phtree.v13.PhTree13;
+import ch.ethz.globis.phtree.v16.PhTree16;
+
+import java.util.Arrays;
+import java.util.Random;
+
+
+public class BenchmarkJava8MapAPI extends TestSuper {
+
+	private static final int N_POINTS = 1_000_000;
+	private static final int DIMS = 3;
+	private static final int LIMIT_MS = 1000;
+
+	public static void main(String[] args) {
+		long[][] data = generate();
+		testGetPut13(data);
+		testGetPut13(data);
+		testGetPut13(data);
+		testGetPut16(data);
+		testGetPut16(data);
+		testGetPut16(data);
+		testCompute16(data);
+		testCompute16(data);
+		testCompute16(data);
+		testGetPut13(data);
+		testGetPut13(data);
+		testGetPut13(data);
+		testGetPut16(data);
+		testGetPut16(data);
+		testGetPut16(data);
+		testCompute16(data);
+		testCompute16(data);
+		testCompute16(data);
+	}
+
+	private static long[][] generate() {
+		long[][] data = new long[N_POINTS][DIMS];
+		Random rnd = new Random(0);
+		for (long[] key : data) {
+			Arrays.setAll(key, v -> rnd.nextInt() % 100000);
+		}
+		return data;
+	}
+
+	private static void testGetPut13(long[][] data) {
+		PhTree13<int[]> tree = new PhTree13<>(DIMS);
+		long t0 = System.currentTimeMillis();
+		int n = 0;
+		while (n % 100 != 0 || System.currentTimeMillis()-t0 < LIMIT_MS) {
+			long[] key = data[n++ % N_POINTS];
+			int[] x = tree.get(key);
+			if (x == null) {
+				x = new int[]{0};
+				tree.put(key, x);
+			} else {
+				x[0]++;
+			}
+		}
+		long t1 = System.currentTimeMillis();
+		System.out.println("PHTree13-GP: " + (t1-t0)/(double)n*1_000_000 + " ops/s");
+	}
+
+	private static void testGetPut16(long[][] data) {
+		PhTree16<int[]> tree = new PhTree16<>(DIMS);
+		long t0 = System.currentTimeMillis();
+		int n = 0;
+		while (n % 100 != 0 || System.currentTimeMillis()-t0 < LIMIT_MS) {
+			long[] key = data[n++ % N_POINTS];
+			int[] x = tree.get(key);
+			if (x == null) {
+				x = new int[]{0};
+				tree.put(key, x);
+			} else {
+				x[0]++;
+			}
+		}
+		long t1 = System.currentTimeMillis();
+		System.out.println("PHTree16-GP: " + (t1-t0)/(double)n*1_000_000 + " ops/s");
+	}
+
+	private static void testCompute16(long[][] data) {
+		PhTree16<int[]> tree = new PhTree16<>(DIMS);
+		long t0 = System.currentTimeMillis();
+		int n = 0;
+		while (n % 100 != 0 || System.currentTimeMillis()-t0 < LIMIT_MS) {
+			long[] key = data[n++ % N_POINTS];
+			tree.compute(key, (longs, ints) -> {
+				if (ints == null) {
+					return new int[]{0};
+				}
+				ints[0]++;
+				return ints;
+			});
+		}
+		long t1 = System.currentTimeMillis();
+		System.out.println("PHTree16-CO: " + (t1-t0)/(double)n*1_000_000 + " ops/s");
+	}
+
+}

--- a/src/test/java/ch/ethz/globis/phtree/test/BenchmarkJava8MapAPI.java
+++ b/src/test/java/ch/ethz/globis/phtree/test/BenchmarkJava8MapAPI.java
@@ -41,15 +41,20 @@ public class BenchmarkJava8MapAPI extends TestSuper {
 
 		Scenario s13getPut =
 				new Scenario("PHTree13-GP: ", () -> new PhTree13<>(DIMS), BenchmarkJava8MapAPI::actionGetPut);
+		Scenario s13comp =
+				new Scenario("PHTree13-CO: ", () -> new PhTree13<>(DIMS), BenchmarkJava8MapAPI::actionCompute);
 		Scenario s16getPut =
 				new Scenario("PHTree16-GP: ", () -> new PhTree16<>(DIMS), BenchmarkJava8MapAPI::actionGetPut);
 		Scenario s16comp =
 				new Scenario("PHTree16-CO: ", () -> new PhTree16<>(DIMS), BenchmarkJava8MapAPI::actionCompute);
 
 		test3(data, s13getPut);
+		test3(data, s13comp);
 		test3(data, s16getPut);
 		test3(data, s16comp);
+
 		test3(data, s13getPut);
+		test3(data, s13comp);
 		test3(data, s16getPut);
 		test3(data, s16comp);
 	}

--- a/src/test/java/ch/ethz/globis/phtree/test/TestJava8MapAPI.java
+++ b/src/test/java/ch/ethz/globis/phtree/test/TestJava8MapAPI.java
@@ -9,6 +9,7 @@ package ch.ethz.globis.phtree.test;
 import ch.ethz.globis.phtree.PhTree;
 import ch.ethz.globis.phtree.test.util.TestSuper;
 import ch.ethz.globis.phtree.test.util.TestUtil;
+import ch.ethz.globis.phtree.v13.PhTree13;
 import ch.ethz.globis.phtree.v16.PhTree16;
 import org.junit.Test;
 
@@ -23,7 +24,7 @@ public class TestJava8MapAPI extends TestSuper {
 	private <T> PhTree<T> create(int dim) {
 		//return TestUtil.newTree(dim);
 		//TODO
-		return new PhTree16<>(dim);
+		return new PhTree13<>(dim);
 	}
 
 	@Test

--- a/src/test/java/ch/ethz/globis/phtree/test/TestJava8MapAPI.java
+++ b/src/test/java/ch/ethz/globis/phtree/test/TestJava8MapAPI.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2011-2016 ETH Zurich. All Rights Reserved.
+ *
+ * This software is the proprietary information of ETH Zurich.
+ * Use is subject to license terms.
+ */
+package ch.ethz.globis.phtree.test;
+
+import ch.ethz.globis.phtree.PhTree;
+import ch.ethz.globis.phtree.test.util.TestSuper;
+import ch.ethz.globis.phtree.test.util.TestUtil;
+import ch.ethz.globis.phtree.v16.PhTree16;
+import org.junit.Test;
+
+import java.util.Random;
+
+import static org.junit.Assert.*;
+
+public class TestJava8MapAPI extends TestSuper {
+
+	private static final int N_POINTS = 1000;
+
+	private <T> PhTree<T> create(int dim) {
+		//return TestUtil.newTree(dim);
+		//TODO
+		return new PhTree16<>(dim);
+	}
+
+	@Test
+	public void testPutIfAbsent() {
+		PhTree<Integer> ind = create(3);
+		Random R = new Random(0);
+		for (int i = 0; i < N_POINTS; i++) {
+			long[] v = new long[]{R.nextInt(), R.nextInt(), R.nextInt()};
+			assertNull(ind.putIfAbsent(v, i));
+			assertEquals(i, (int) ind.putIfAbsent(v, -i));
+			assertEquals(i, (int) ind.get(v));
+		}
+		assertEquals(N_POINTS, ind.size());
+	}
+
+	@Test
+	public void testComputeIfAbsent() {
+		PhTree<Integer> ind = create(3);
+		Random R = new Random(0);
+		for (int i = 0; i < N_POINTS; i++) {
+			long[] v = new long[]{R.nextInt(), R.nextInt(), R.nextInt()};
+			final int i2 = i;
+			assertEquals(i2, (int) ind.computeIfAbsent(v, k -> i2));
+			assertEquals(i2, (int) ind.computeIfAbsent(v, k -> -i2));
+			assertEquals(i2, (int) ind.get(v));
+		}
+		assertEquals(N_POINTS, ind.size());
+	}
+
+	@Test
+	public void testComputeIfPresent() {
+		PhTree<Integer> ind = create(3);
+		Random R = new Random(0);
+		long[][] points = new long[N_POINTS][];
+		for (int i = 0; i < points.length; i++) {
+			long[] v = new long[]{R.nextInt(), R.nextInt(), R.nextInt()};
+			points[i] = v;
+			final int i2 = i;
+			assertNull(ind.computeIfPresent(v, (longs, integer) -> i2));
+			assertFalse(ind.contains(v));
+			ind.put(v, i2);
+			assertEquals(-i2, (int) ind.computeIfPresent(v, (longs, integer) -> -i2));
+			assertEquals(-i2, (int) ind.get(v));
+		}
+		assertEquals(N_POINTS, ind.size());
+		for (long[] v : points) {
+			assertTrue(ind.contains(v));
+			assertNull(ind.computeIfPresent(v, (longs, integer) -> null));
+			assertFalse(ind.contains(v));
+		}
+		assertEquals(0, ind.size());
+	}
+
+	@Test
+	public void testCompute() {
+		PhTree<Integer> ind = create(3);
+		Random R = new Random(0);
+		long[][] points = new long[N_POINTS][];
+		for (int i = 0; i < points.length; i++) {
+			long[] v = new long[]{R.nextInt(), R.nextInt(), R.nextInt()};
+			points[i] = v;
+			final int i2 = i;
+			assertNull(ind.compute(v, (longs, integer) -> {
+				assertNull(integer);
+				return null;
+			}));
+			assertFalse(ind.contains(v));
+			assertEquals(i2, (int) ind.compute(v, (longs, integer) -> {
+				assertNull(integer);
+				return i2;
+			}));
+			assertEquals(i2, (int) ind.get(v));
+			assertEquals(-i2, (int) ind.compute(v, (longs, integer) -> {
+				assertEquals(i2, (int) integer);
+				return -i2;
+			}));
+			assertEquals(-i2, (int) ind.get(v));
+		}
+		assertEquals(N_POINTS, ind.size());
+		for (int i = 0; i < points.length; i++) {
+			long[] v = points[i];
+			final int i2 = i;
+			assertNull(ind.compute(v, (longs, integer) -> {
+				assertEquals(-i2, (int) integer);
+				return null;
+			}));
+			assertFalse(ind.contains(v));
+		}
+		assertEquals(0, ind.size());
+	}
+
+	@Test
+	public void testGetOrDefault() {
+		PhTree<Integer> ind = create(2);
+		Random R = new Random(0);
+		for (int i = 0; i < N_POINTS; i++) {
+			long[] v = new long[]{R.nextInt(), R.nextInt()};
+			assertEquals(i + 15, (int) ind.getOrDefault(v, i+15));
+			ind.put(v, -i);
+			assertEquals(-i, (int) ind.getOrDefault(v, i+17));
+		}
+	}
+
+	@Test
+	public void testRemoveExact() {
+		PhTree<Integer> ind = create(3);
+		Random R = new Random(0);
+		long[][] points = new long[N_POINTS][];
+		for (int i = 0; i < points.length; i++) {
+			long[] v = new long[]{R.nextInt(), R.nextInt(), R.nextInt()};
+			points[i] = v;
+			assertFalse(ind.remove(v, i));
+			ind.put(v, i);
+			assertFalse(ind.remove(v, i+1));
+		}
+		assertEquals(N_POINTS, ind.size());
+		for (int i = 0; i < points.length; i++) {
+			long[] v = points[i];
+			assertTrue(ind.contains(v));
+			assertFalse(ind.remove(v, i+1));
+			assertTrue(ind.contains(v));
+			assertTrue(ind.remove(v, i));
+			assertFalse(ind.contains(v));
+		}
+		assertEquals(0, ind.size());
+	}
+
+	@Test
+	public void testReplace() {
+		PhTree<Integer> ind = create(3);
+		Random R = new Random(0);
+		long[][] points = new long[N_POINTS][];
+		for (int i = 0; i < points.length; i++) {
+			long[] v = new long[]{R.nextInt(), R.nextInt(), R.nextInt()};
+			points[i] = v;
+			assertNull(ind.replace(v, i));
+			assertFalse(ind.contains(v));
+			ind.put(v, i);
+			assertEquals(i, (int) ind.replace(v, i+1));
+			assertEquals(i+1, (int) ind.get(v));
+		}
+		assertEquals(N_POINTS, ind.size());
+	}
+
+	@Test
+	public void testReplaceExact() {
+		PhTree<Integer> ind = create(3);
+		Random R = new Random(0);
+		long[][] points = new long[N_POINTS][];
+		for (int i = 0; i < points.length; i++) {
+			long[] v = new long[]{R.nextInt(), R.nextInt(), R.nextInt()};
+			points[i] = v;
+			assertFalse(ind.replace(v, null, i));
+			assertFalse(ind.replace(v, i, i));
+			assertFalse(ind.contains(v));
+			ind.put(v, i);
+			assertFalse(ind.replace(v, i+1, i));
+			assertEquals(i, (int) ind.get(v));
+			assertTrue(ind.replace(v, i, i+5));
+			assertEquals(i+5, (int) ind.get(v));
+		}
+		assertEquals(N_POINTS, ind.size());
+	}
+
+}

--- a/src/test/java/ch/ethz/globis/phtree/test/TestValues.java
+++ b/src/test/java/ch/ethz/globis/phtree/test/TestValues.java
@@ -30,30 +30,30 @@ import ch.ethz.globis.phtree.test.util.TestUtil;
 
 public class TestValues extends TestSuper {
 
-    public static <T> PhTree<T> createTree(int dim, int depth) {
-    	return TestUtil.newTree(dim, depth);
+    private static <T> PhTree<T> createTree(int dim) {
+    	return TestUtil.newTree(dim);
     }
     
 	@Test
 	public void test3D() {
-		smokeTest(10000, 3, 32, 0);
+		smokeTest(10000, 3, 0);
 	}
 	
 	@Test
 	public void test2D() {
-		smokeTest(100000, 2, 32, 0);
+		smokeTest(100000, 2, 0);
 	}
 	
 	@Test
 	public void test2D_8() {
-		smokeTest(100, 2, 32, 2);
+		smokeTest(100, 2, 2);
 	}
 	
 	@Test
 	public void test2D_8_Bug10b() {
 //		for (int i = 0; i < 10000; i++) {
 //			System.out.println("iii=" + i);
-			smokeTest(5, 2, 32, 1619);
+			smokeTest(5, 2, 1619);
 //		}
 	}
 	
@@ -61,13 +61,13 @@ public class TestValues extends TestSuper {
 	public void test2D_8_BugNP() {
 //		for (int i = 0; i < 1000; i++) {
 //			System.out.println("iii=" + i);
-			smokeTest(20, 2, 32, 205);
+			smokeTest(20, 2, 205);
 //		}
 	}
 	
-	private void smokeTest(int N, int DIM, int DEPTH, long SEED) { 
+	private void smokeTest(int N, int DIM, long SEED) {
 		Random R = new Random(SEED);
-		PhTree<Integer> ind = createTree(DIM, DEPTH);
+		PhTree<Integer> ind = createTree(DIM);
 		long[][] keys = new long[N][DIM];
 		for (int i = 0; i < N; i++) {
 			for (int d = 0; d < DIM; d++) {
@@ -78,7 +78,7 @@ public class TestValues extends TestSuper {
 				continue;
 			}
 			//build
-			assertNull(ind.put(keys[i], Integer.valueOf(i)));
+			assertNull(ind.put(keys[i], i));
 			//System.out.println("key=" + Bits.toBinary(keys[i], 64));
 			//System.out.println(ind);
 			assertTrue("i="+ i, ind.contains(keys[i]));
@@ -94,7 +94,7 @@ public class TestValues extends TestSuper {
 		
 		//update
 		for (int i = 0; i < N; i++) {
-			assertEquals(i, (int)ind.put(keys[i], Integer.valueOf(-i)));
+			assertEquals(i, (int)ind.put(keys[i], -i));
 			assertTrue(ind.contains(keys[i]));
 			assertEquals(-i, (int)ind.get(keys[i]));
 		}
@@ -124,7 +124,7 @@ public class TestValues extends TestSuper {
 				{0b00100001, 0b10110100},//   v=null
 		};
 		
-		PhTree<Integer> ind = createTree(2, 16);
+		PhTree<Integer> ind = createTree(2);
 
 		ind.put(keys[0], 0);
 		assertNotNull(ind.get(keys[0]));
@@ -156,7 +156,7 @@ public class TestValues extends TestSuper {
 				{0.7713129661706796, 0.7126874281456893, 0.2112353749298962, 0.7830924897671794, 0.945333238959629, 0.014236355103667941} 
 		};
 		
-		PhTree<Object> ind = createTree(DIM, 64);
+		PhTree<Object> ind = createTree(DIM);
 
 		Object V = new Object();
 		for (int i = 0; i < keysD.length; i++) {
@@ -173,9 +173,8 @@ public class TestValues extends TestSuper {
 	public void testQuery() {
 		int N = 1000;
 		int DIM = 3;
-		int DEPTH = 64; 
 		Random R = new Random(0);
-		PhTree<Integer> ind = createTree(DIM, DEPTH);
+		PhTree<Integer> ind = createTree(DIM);
 		long[][] keys = new long[N][DIM];
 		for (int i = 0; i < N; i++) {
 			for (int d = 0; d < DIM; d++) {
@@ -186,8 +185,10 @@ public class TestValues extends TestSuper {
 				continue;
 			}
 			//build
-			assertNull(ind.put(keys[i], Integer.valueOf(i)));
+			assertNull(ind.put(keys[i], i));
 			assertTrue(ind.contains(keys[i]));
+			ind.getStats();
+			assertEquals(i+1, ind.size());
 			assertEquals(i, (int)ind.get(keys[i]));
 		}
 
@@ -242,8 +243,7 @@ public class TestValues extends TestSuper {
 	@Test
 	public void testQueryBug() {
 		int DIM = 3;
-		int DEPTH = 64; 
-		PhTree<Integer> ind = createTree(DIM, DEPTH);
+		PhTree<Integer> ind = createTree(DIM);
 		long[][] keys = {
 				{629649304, -1266264776, 99807007},
 				{5955764, -1946737912, 39620447},
@@ -256,7 +256,7 @@ public class TestValues extends TestSuper {
 				continue;
 			}
 			//build
-			assertNull(ind.put(keys[i], Integer.valueOf(i)));
+			assertNull(ind.put(keys[i], i));
 			assertTrue(ind.contains(keys[i]));
 			assertEquals(i, (int)ind.get(keys[i]));
 		}
@@ -312,9 +312,8 @@ public class TestValues extends TestSuper {
 	public void testQuerySet() {
 		int N = 1000;
 		int DIM = 3;
-		int DEPTH = 64; 
 		Random R = new Random(0);
-		PhTree<Integer> ind = createTree(DIM, DEPTH);
+		PhTree<Integer> ind = createTree(DIM);
 		long[][] keys = new long[N][DIM];
 		for (int i = 0; i < N; i++) {
 			for (int d = 0; d < DIM; d++) {
@@ -325,7 +324,7 @@ public class TestValues extends TestSuper {
 				continue;
 			}
 			//build
-			assertNull(ind.put(keys[i], Integer.valueOf(i)));
+			assertNull(ind.put(keys[i], i));
 			assertTrue(ind.contains(keys[i]));
 			assertEquals(i, (int)ind.get(keys[i]));
 		}


### PR DESCRIPTION
This PR provides Java 8 Map API methods for V13 and V16. So far, only comput() and compute() id present are better than the naïve implementation.

Also: several minor speed improvements.

GP = get() + put()
CO = compute()
```
PHTree13-GP: 1508700.0 ops/s
PHTree13-GP: 1603900.0 ops/s
PHTree13-GP: 1615100.0 ops/s

PHTree13-CO: 2.49887E7 ops/s
PHTree13-CO: 2.44802E7 ops/s
PHTree13-CO: 2.54971E7 ops/s

PHTree16-GP: 1052500.0 ops/s
PHTree16-GP: 965800.0 ops/s
PHTree16-GP: 1057600.0 ops/s

PHTree16-CO: 1222300.0 ops/s
PHTree16-CO: 1230000.0 ops/s
PHTree16-CO: 1232300.0 ops/s
```